### PR TITLE
main.py: add --dump option.

### DIFF
--- a/examples/gpt2/README.md
+++ b/examples/gpt2/README.md
@@ -12,6 +12,7 @@ This example demonstrates how to invoke llaf from Python to produce text using G
         * Options are `gpt2`, `gpt2-medium`, `gpt2-large`, and `gpt2-xl`.
     * `--cnt`: Number of additional tokens to generate.
     * `--benchmark`: Flag for benchmarking llaf against Hugging Face.
+    * `--dump DIR`: dumps parameters and encoded prompt to the given directory as individual files in the Futhark binary data format.
 
 With the initial prompt of `Once upon a time`, laff can be anywhere from 3x to 10x slower than the Hugging Face implementation of GPT-2 on an RTX 2070 GPU, as seen below. Despite its poor relative performance, the Futhark compiler still does a decent job, especially considering that it's aimed towards general array computations and isn't optimized for deep learning.
 

--- a/examples/gpt2/requirements.txt
+++ b/examples/gpt2/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pyopencl
 torch
 transformers
+futhark-data


### PR DESCRIPTION
This is mainly useful for extracting input data that can then be used with futhark-bench for profiling purposes. E.g. after dumping these in an appropriate directory I can use the following stanza in `llm.fut`:

```
-- ==
-- entry: gen
-- "gpt2"
-- script input { ($loaddata "gpt2/ids.data",
--                 init ($loaddata "gpt2/tok_emb.data")
--                      ($loaddata "gpt2/pos_emb.data")
--                      ($loaddata "gpt2/gamma1s.data")
--                      ($loaddata "gpt2/beta1s.data")
--                      ($loaddata "gpt2/gamma2s.data")
--                      ($loaddata "gpt2/beta2s.data")
--                      ($loaddata "gpt2/w_ins.data")
--                      ($loaddata "gpt2/b_ins.data")
--                      ($loaddata "gpt2/w_outs.data")
--                      ($loaddata "gpt2/b_outs.data")
--                      ($loaddata "gpt2/w1s.data")
--                      ($loaddata "gpt2/b1s.data")
--                      ($loaddata "gpt2/w2s.data")
--                      ($loaddata "gpt2/b2s.data")
--                      ($loaddata "gpt2/gamma.data")
--                      ($loaddata "gpt2/beta.data")
--                      ($loaddata "gpt2/w.data"),
--                 100i64)}
```